### PR TITLE
Default the Buzzer and LED to enabled

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -33,6 +33,8 @@ esphome:
         green: 0%
         blue: 100%
         flash_length: 500ms
+    - switch.turn_on: buzzer_enabled
+    - switch.turn_on: led_enabled
 
 # Define switches to control LED and buzzer from HA
 switch:


### PR DESCRIPTION
on startup enable the busser and the LED. I made this change to my reader after noticing that the restore state dose does not work most of the time. Defaulting to enabled comes from feedback from noticing the tag users scanning the tag more than ones thinking that the tag was not scanned.